### PR TITLE
fix: add explicit permissions to lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: Lint
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary
- Adds top-level `permissions: contents: read` to the lint workflow
- Resolves both code scanning alerts (#1 and #2) for missing workflow permissions
- Applies the principle of least privilege — lint jobs only need read access

## Test plan
- [x] Verify the lint workflow still runs successfully on this PR
- [x] Confirm both code scanning alerts are resolved after merge