### PR TITLE
fix: read imgproxy credentials from wp-config.php constants

### DIFF
--- a/includes/class-image-proxy.php
+++ b/includes/class-image-proxy.php
@@ -3,8 +3,8 @@
  * Image proxy (imgproxy) integration.
  *
  * Rewrites image URLs through an imgproxy service for on-the-fly resizing.
- * Uses the same WordPress options as the streekomroep-wp theme:
- * imgproxy_url, imgproxy_key, imgproxy_salt.
+ * Uses the same wp-config.php constants as the streekomroep-wp theme:
+ * IMGPROXY_URL, IMGPROXY_KEY, IMGPROXY_SALT.
  *
  * @package ZWGR26
  */
@@ -51,12 +51,12 @@ class Image_Proxy {
 	private string $salt_bin;
 
 	/**
-	 * Constructor — reads imgproxy credentials from WordPress options.
+	 * Constructor — reads imgproxy credentials from wp-config.php constants.
 	 */
 	public function __construct() {
-		$this->host = get_option( 'imgproxy_url', '' );
-		$key        = get_option( 'imgproxy_key', '' );
-		$salt       = get_option( 'imgproxy_salt', '' );
+		$this->host = defined( 'IMGPROXY_URL' ) ? IMGPROXY_URL : '';
+		$key        = defined( 'IMGPROXY_KEY' ) ? IMGPROXY_KEY : '';
+		$salt       = defined( 'IMGPROXY_SALT' ) ? IMGPROXY_SALT : '';
 
 		$this->enabled = ! empty( $this->host ) && ! empty( $key ) && ! empty( $salt );
 

--- a/zw-gr26.php
+++ b/zw-gr26.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: ZuidWest GR 2026
  * Description: Gemeenteraadsverkiezingen 2026 pagina's voor de site en app van Streekomroep ZuidWest.
- * Version: 0.5.1
+ * Version: 0.5.2
  * Author: Streekomroep ZuidWest
  * Text Domain: zw-gr26
  * License: GPL-2.0-or-later


### PR DESCRIPTION
## Summary
- The streekomroep-wp theme switched imgproxy config from `get_option()` calls to `wp-config.php` constants (`IMGPROXY_KEY`, `IMGPROXY_SALT`, `IMGPROXY_URL`) in oszuidwest/streekomroep-wp@ff5e688
- This plugin's `Image_Proxy` class still read the old database options, so imgproxy would silently stop working
- Updated to use `defined()` checks matching the theme's new approach