### PR TITLE
chore: align phpcs.xml.dist with shared baseline

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,33 +1,25 @@
 <?xml version="1.0"?>
-<ruleset name="ZW-GR26 Coding Standards">
-    <description>WordPress Coding Standards for ZuidWest GR 2026 plugin</description>
+<ruleset name="zw-gr26-wp">
+    <description>WordPress Coding Standards for ZuidWest GR 2026.</description>
 
-    <!-- What to scan -->
+    <!-- Files to scan -->
     <file>zw-gr26-wp.php</file>
     <file>includes</file>
     <file>shortcodes</file>
 
-    <!-- Exclude vendor directory -->
-    <exclude-pattern>vendor/*</exclude-pattern>
-
-    <!-- Arguments -->
+    <!-- Tooling -->
     <arg name="extensions" value="php"/>
     <arg name="colors"/>
-    <arg value="sp"/> <!-- Show sniff codes and progress -->
+    <arg value="sp"/>
 
-    <!-- Fix PHP 8 deprecation warnings in PHPCS -->
     <ini name="error_reporting" value="E_ALL &amp; ~E_DEPRECATED"/>
 
-    <!-- WordPress version: 6.8+ -->
+    <!-- Versions -->
+    <config name="testVersion" value="8.3-8.4"/>
     <config name="minimum_wp_version" value="6.8"/>
 
-    <!-- PHP Compatibility: 8.3 to 8.4 -->
-    <config name="testVersion" value="8.3-8.4"/>
-
-    <!-- Text domain for i18n -->
+    <!-- Per-plugin -->
     <config name="text_domain" value="zw-gr26"/>
-
-    <!-- Prefixes for globals -->
     <rule ref="WordPress.NamingConventions.PrefixAllGlobals">
         <properties>
             <property name="prefixes" type="array">
@@ -38,16 +30,15 @@
         </properties>
     </rule>
 
-    <!-- Use WordPress-Extra as base (includes Core + best practices) -->
+    <!-- Standards -->
     <rule ref="WordPress-Extra">
-        <!-- Allow short array syntax -->
         <exclude name="Universal.Arrays.DisallowShortArraySyntax"/>
     </rule>
-
-    <!-- PHP Compatibility -->
+    <rule ref="WordPress-Docs">
+        <exclude name="Squiz.Commenting.FunctionComment.IncorrectTypeHint"/>
+    </rule>
     <rule ref="PHPCompatibilityWP"/>
 
-    <!-- Line length: allow up to 160 characters, warn after -->
     <rule ref="Generic.Files.LineLength">
         <properties>
             <property name="lineLimit" value="160"/>
@@ -55,9 +46,6 @@
         </properties>
     </rule>
 
-    <!-- WordPress documentation standards -->
-    <rule ref="WordPress-Docs">
-        <!-- PHPStan type aliases aren't real PHP types -->
-        <exclude name="Squiz.Commenting.FunctionComment.IncorrectTypeHint"/>
-    </rule>
+    <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>node_modules/*</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
Aligns this plugin's phpcs config with the shared baseline shipped in oszuidwest/.github-templates@v2.2.3 (`config-templates/phpcs.xml.dist`).

## What changed

- Replaced the per-plugin `phpcs.xml` with `phpcs.xml.dist` whose rule stack matches the canonical baseline (WordPress-Extra + WordPress-Docs + PHPCompatibilityWP, PHP 8.3-8.4, WP 6.8+, 160-char line limit, vendor/node_modules excluded).
- Per-plugin specifics (file globs, text_domain config, PrefixAllGlobals rule) layer on top.

## Why `.dist`

`phpcs.xml.dist` matches the template's filename and is the conventional name for committed defaults; `phpcs.xml` is reserved for local overrides. Lint workflows already path-trigger on both filenames so the rename has no CI impact.

## Test plan

- [ ] CI passes on this PR (lint job picks up the new `.dist` file).